### PR TITLE
Unset empty signing/notarization secrets in release workflows to prevent macOS packaging failures

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -280,7 +280,13 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npm run ${{ matrix.target.script }}
+        run: |
+          [ -n "${CSC_LINK}" ] || unset CSC_LINK
+          [ -n "${CSC_KEY_PASSWORD}" ] || unset CSC_KEY_PASSWORD
+          [ -n "${APPLE_ID}" ] || unset APPLE_ID
+          [ -n "${APPLE_ID_PASSWORD}" ] || unset APPLE_ID_PASSWORD
+          [ -n "${APPLE_TEAM_ID}" ] || unset APPLE_TEAM_ID
+          npm run ${{ matrix.target.script }}
 
       - name: Build installer artifacts (Windows)
         if: matrix.target.id == 'win'
@@ -290,7 +296,10 @@ jobs:
           # WIN_CSC_KEY_PASSWORD – passphrase for the Windows .p12 certificate
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        run: npm run ${{ matrix.target.script }}
+        run: |
+          [ -n "${WIN_CSC_LINK}" ] || unset WIN_CSC_LINK
+          [ -n "${WIN_CSC_KEY_PASSWORD}" ] || unset WIN_CSC_KEY_PASSWORD
+          npm run ${{ matrix.target.script }}
 
       - name: Build installer artifacts (Linux)
         if: matrix.target.id == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,13 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npm run ${{ matrix.target.script }}
+        run: |
+          [ -n "${CSC_LINK}" ] || unset CSC_LINK
+          [ -n "${CSC_KEY_PASSWORD}" ] || unset CSC_KEY_PASSWORD
+          [ -n "${APPLE_ID}" ] || unset APPLE_ID
+          [ -n "${APPLE_ID_PASSWORD}" ] || unset APPLE_ID_PASSWORD
+          [ -n "${APPLE_TEAM_ID}" ] || unset APPLE_TEAM_ID
+          npm run ${{ matrix.target.script }}
 
       - name: Build installer artifacts (Windows)
         if: matrix.target.id == 'win'
@@ -102,7 +108,10 @@ jobs:
           # WIN_CSC_KEY_PASSWORD – passphrase for the Windows .p12 certificate
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        run: npm run ${{ matrix.target.script }}
+        run: |
+          [ -n "${WIN_CSC_LINK}" ] || unset WIN_CSC_LINK
+          [ -n "${WIN_CSC_KEY_PASSWORD}" ] || unset WIN_CSC_KEY_PASSWORD
+          npm run ${{ matrix.target.script }}
 
       - name: Build installer artifacts (Linux)
         if: matrix.target.id == 'linux'


### PR DESCRIPTION
### Motivation
- CI macOS packaging can fail when electron-builder receives signing/notarization env vars that are present but empty, producing errors like `... not a file`.
- The change ensures optional code signing and notarization remain available when secrets are set, while avoiding hard failures when secrets are empty.
- This is a follow-up to prior config fixes for electron-builder schema compatibility to make mac packaging robust in GitHub Actions.

### Description
- Updated `.github/workflows/release.yml` to unset empty values for `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, and `APPLE_TEAM_ID` before running the macOS packaging step with `npm run ${matrix.target.script}`.
- Applied the same empty-value unsetting for Windows signing vars `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` in the same workflow.
- Mirrored both changes into `.github/workflows/auto-release.yml` so the auto-release pipeline has the same guards and behavior.

### Testing
- Ran `npm run lint` and the type-checking `tsc` step succeeded.
- Ran `npm run electron:build` and the Electron build step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab91f41c1c8327b5d311ead54cddaa)